### PR TITLE
Fixed asset on non root app

### DIFF
--- a/resources/views/upload/index.twig
+++ b/resources/views/upload/index.twig
@@ -3,12 +3,12 @@
 {{ asset_add('scripts.js', 'anomaly.field_type.files::js/dropzone.min.js') }}
 {{ asset_add('scripts.js', 'anomaly.field_type.files::js/upload.js') }}
 
-{% for path in asset_paths("styles.css") %}
-    {{ html_style(path) }}
+{% for style in asset_styles("styles.css") %}
+    {{ style|raw }}
 {% endfor %}
 
-{% for path in asset_paths("scripts.js") %}
-    {{ html_script(path) }}
+{% for script in asset_scripts("scripts.js") %}
+    {{ script|raw }}
 {% endfor %}
 
 <div id="upload">


### PR DESCRIPTION
If the application is not hosted on the root, the assets fail to be load (the directories are doubled)

![Screenshot](https://user-images.githubusercontent.com/2734125/64460279-32a1c080-d124-11e9-8e40-c67deb7f7b60.png)
